### PR TITLE
Handle feed with one entry

### DIFF
--- a/meteoalertapi/meteoalertapi.py
+++ b/meteoalertapi/meteoalertapi.py
@@ -33,7 +33,8 @@ class Meteoalert(object):
 
         feed_data = xmltodict.parse(text)
         feed = feed_data.get('feed', [])
-        for entry in feed.get('entry', []):
+        entries = feed.get('entry', [])
+        for entry in (entries if type(entries) is list else [entries]):
             if entry.get('cap:areaDesc') != self.province:
                 continue
 


### PR DESCRIPTION
```
meteoalarm: Error on device update!
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/helpers/entity_platform.py", line 292, in _async_add_entity
    await entity.async_device_update(warning=False)
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 450, in async_device_update
    await self.hass.async_add_executor_job(self.update)
  File "/usr/local/lib/python3.7/concurrent/futures/thread.py", line 57, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/usr/src/homeassistant/homeassistant/components/meteoalarm/binary_sensor.py", line 85, in update
    alert = self._api.get_alert()
  File "/usr/local/lib/python3.7/site-packages/meteoalertapi/meteoalertapi.py", line 37, in get_alert
    if entry.get('cap:areaDesc') != self.province:
AttributeError: 'str' object has no attribute 'get'
```
This error came up every time when the ATOM feed contained only one entry. In this case the for loop iterated through that single entry's keys instead of a one-element list.
The only change I made is to put the entry in a list if the feed does not return one.
