### PR TITLE
Add license tag

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ setuptools.setup(
     author="Rolf Berkenbosch",
     author_email="rolf@berkenbosch.nl",
     description="A small api to get alerting messages from extreme weather in Europe from https://www.meteoalarm.org.",
+    license="MIT",
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/rolfberkenbosch/meteoalarm-api",


### PR DESCRIPTION
Allow third-party tools (e. g., PyPI or `pyp2rpm`) to get the license details in a simple way.