### PR TITLE
update setup.py, exclude "tests"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setuptools.setup(
         'xmltodict',
         'requests',
     ],
-    packages=setuptools.find_packages(),
+    packages=setuptools.find_packages(exclude=['tests']),
     classifiers=(
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
otherwise it would try to install it top level:

```
>>> Jobs: 0 of 1 complete, 1 failed                 Load avg: 0.59, 0.36, 0.31
 * Package:    dev-python/meteoalertapi-0.2.0
 * Repository: HomeAssistantRepository
 * Maintainer: b@edevau.net
 * Upstream:   rolf@berkenbosch.nl
 * USE:        abi_x86_64 amd64 elibc_glibc kernel_linux python_targets_python3_9 test userland_GNU
 * FEATURES:   network-sandbox preserve-libs sandbox userpriv usersandbox
>>> Unpacking source...
>>> Unpacking meteoalertapi-0.2.0.tar.gz to /var/tmp/portage/dev-python/meteoalertapi-0.2.0/work
>>> Source unpacked in /var/tmp/portage/dev-python/meteoalertapi-0.2.0/work
>>> Preparing source in /var/tmp/portage/dev-python/meteoalertapi-0.2.0/work/meteoalertapi-0.2.0 ...
>>> Source prepared.
>>> Configuring source in /var/tmp/portage/dev-python/meteoalertapi-0.2.0/work/meteoalertapi-0.2.0 ...
>>> Source configured.
>>> Compiling source in /var/tmp/portage/dev-python/meteoalertapi-0.2.0/work/meteoalertapi-0.2.0 ...
 * python3_9: running distutils-r1_run_phase distutils-r1_python_compile
python3.9 setup.py build -j 6
Warning: 'classifiers' should be a list, got type 'tuple'
running build
running build_py
creating /var/tmp/portage/dev-python/meteoalertapi-0.2.0/work/meteoalertapi-0.2.0-python3_9/lib/tests
copying tests/test_meteoalertapi.py -> /var/tmp/portage/dev-python/meteoalertapi-0.2.0/work/meteoalertapi-0.2.0-python3_9/lib/tests
copying tests/__init__.py -> /var/tmp/portage/dev-python/meteoalertapi-0.2.0/work/meteoalertapi-0.2.0-python3_9/lib/tests
creating /var/tmp/portage/dev-python/meteoalertapi-0.2.0/work/meteoalertapi-0.2.0-python3_9/lib/meteoalertapi
copying meteoalertapi/__init__.py -> /var/tmp/portage/dev-python/meteoalertapi-0.2.0/work/meteoalertapi-0.2.0-python3_9/lib/meteoalertapi
copying meteoalertapi/meteoalertapi.py -> /var/tmp/portage/dev-python/meteoalertapi-0.2.0/work/meteoalertapi-0.2.0-python3_9/lib/meteoalertapi
warning: build_py: byte-compiling is disabled, skipping.

>>> Source compiled.
>>> Test phase [not enabled]: dev-python/meteoalertapi-0.2.0

>>> Install dev-python/meteoalertapi-0.2.0 into /var/tmp/portage/dev-python/meteoalertapi-0.2.0/image
 * python3_9: running distutils-r1_run_phase distutils-r1_python_install
python3.9 setup.py install --skip-build --root=/var/tmp/portage/dev-python/meteoalertapi-0.2.0/image/_python3.9
Warning: 'classifiers' should be a list, got type 'tuple'
running install
running install_lib
creating /var/tmp/portage/dev-python/meteoalertapi-0.2.0/image/_python3.9
creating /var/tmp/portage/dev-python/meteoalertapi-0.2.0/image/_python3.9/usr
creating /var/tmp/portage/dev-python/meteoalertapi-0.2.0/image/_python3.9/usr/lib
creating /var/tmp/portage/dev-python/meteoalertapi-0.2.0/image/_python3.9/usr/lib/python3.9
creating /var/tmp/portage/dev-python/meteoalertapi-0.2.0/image/_python3.9/usr/lib/python3.9/site-packages
creating /var/tmp/portage/dev-python/meteoalertapi-0.2.0/image/_python3.9/usr/lib/python3.9/site-packages/tests
copying /var/tmp/portage/dev-python/meteoalertapi-0.2.0/work/meteoalertapi-0.2.0-python3_9/lib/tests/test_meteoalertapi.py -> /var/tmp/portage/dev-python/meteoalertapi-0.2.0/image/_python3.9/usr/lib/python3.9/site-packages/tests
copying /var/tmp/portage/dev-python/meteoalertapi-0.2.0/work/meteoalertapi-0.2.0-python3_9/lib/tests/__init__.py -> /var/tmp/portage/dev-python/meteoalertapi-0.2.0/image/_python3.9/usr/lib/python3.9/site-packages/tests
creating /var/tmp/portage/dev-python/meteoalertapi-0.2.0/image/_python3.9/usr/lib/python3.9/site-packages/meteoalertapi
copying /var/tmp/portage/dev-python/meteoalertapi-0.2.0/work/meteoalertapi-0.2.0-python3_9/lib/meteoalertapi/__init__.py -> /var/tmp/portage/dev-python/meteoalertapi-0.2.0/image/_python3.9/usr/lib/python3.9/site-packages/meteoalertapi
copying /var/tmp/portage/dev-python/meteoalertapi-0.2.0/work/meteoalertapi-0.2.0-python3_9/lib/meteoalertapi/meteoalertapi.py -> /var/tmp/portage/dev-python/meteoalertapi-0.2.0/image/_python3.9/usr/lib/python3.9/site-packages/meteoalertapi
byte-compiling /var/tmp/portage/dev-python/meteoalertapi-0.2.0/image/_python3.9/usr/lib/python3.9/site-packages/tests/test_meteoalertapi.py to test_meteoalertapi.cpython-39.pyc
byte-compiling /var/tmp/portage/dev-python/meteoalertapi-0.2.0/image/_python3.9/usr/lib/python3.9/site-packages/tests/__init__.py to __init__.cpython-39.pyc
byte-compiling /var/tmp/portage/dev-python/meteoalertapi-0.2.0/image/_python3.9/usr/lib/python3.9/site-packages/meteoalertapi/__init__.py to __init__.cpython-39.pyc
byte-compiling /var/tmp/portage/dev-python/meteoalertapi-0.2.0/image/_python3.9/usr/lib/python3.9/site-packages/meteoalertapi/meteoalertapi.py to meteoalertapi.cpython-39.pyc
writing byte-compilation script '/var/tmp/portage/dev-python/meteoalertapi-0.2.0/temp/tmpp84y3zcv.py'
/usr/bin/python3.9 /var/tmp/portage/dev-python/meteoalertapi-0.2.0/temp/tmpp84y3zcv.py
removing /var/tmp/portage/dev-python/meteoalertapi-0.2.0/temp/tmpp84y3zcv.py
writing byte-compilation script '/var/tmp/portage/dev-python/meteoalertapi-0.2.0/temp/tmp8albhqhk.py'
/usr/bin/python3.9 /var/tmp/portage/dev-python/meteoalertapi-0.2.0/temp/tmp8albhqhk.py
removing /var/tmp/portage/dev-python/meteoalertapi-0.2.0/temp/tmp8albhqhk.py
running install_egg_info
running egg_info
writing meteoalertapi.egg-info/PKG-INFO
writing dependency_links to meteoalertapi.egg-info/dependency_links.txt
writing requirements to meteoalertapi.egg-info/requires.txt
writing top-level names to meteoalertapi.egg-info/top_level.txt
reading manifest file 'meteoalertapi.egg-info/SOURCES.txt'
adding license file 'LICENSE'
writing manifest file 'meteoalertapi.egg-info/SOURCES.txt'
Copying meteoalertapi.egg-info to /var/tmp/portage/dev-python/meteoalertapi-0.2.0/image/_python3.9/usr/lib/python3.9/site-packages/meteoalertapi-0.2.0-py3.9.egg-info
running install_scripts
 * ERROR: dev-python/meteoalertapi-0.2.0::HomeAssistantRepository failed (install phase):
 *   Package installs 'tests' package which is forbidden and likely a bug in the build system.
```